### PR TITLE
Use built-in unittest module instead of pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -m mypy -p tinytag
 
       - name: Unit tests
-        run: python -m coverage run -m pytest
+        run: python -m coverage run -m unittest
         env:
           TINYTAG_DEBUG: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ tests = [
     "coverage",
     "mypy",
     "pycodestyle",
-    "pylint",
-    "pytest"
+    "pylint"
 ]
 
 [tool.flit.sdist]

--- a/tinytag/tests/test_cli.py
+++ b/tinytag/tests/test_cli.py
@@ -1,24 +1,22 @@
 # SPDX-FileCopyrightText: 2020-2024 tinytag Contributors
 # SPDX-License-Identifier: MIT
 
-# pylint: disable=missing-function-docstring,missing-module-docstring
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=missing-module-docstring
 
 import json
 import os
-import sys
 
 from subprocess import check_output, CalledProcessError, STDOUT
+from sys import executable
 from tempfile import NamedTemporaryFile
+from unittest import TestCase
 
-import pytest
-
-project_folder = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-sample_folder = os.path.join(project_folder, 'tinytag', 'tests', 'samples')
-mp3_with_img = os.path.join(sample_folder, 'image-text-encoding.mp3')
-bogus_file = os.path.join(sample_folder, 'there_is_no_such_ext.bogus')
-assert os.path.exists(mp3_with_img)
-
-tinytag_attributes = {
+PROJECT_FOLDER = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+SAMPLE_FOLDER = os.path.join(PROJECT_FOLDER, 'tinytag', 'tests', 'samples')
+MP3_WITH_IMG = os.path.join(SAMPLE_FOLDER, 'image-text-encoding.mp3')
+BOGUS_FILE = os.path.join(SAMPLE_FOLDER, 'there_is_no_such_ext.bogus')
+TINYTAG_ATTRIBUTES = {
     'album', 'albumartist', 'artist', 'bitdepth', 'bitrate',
     'channels', 'comment', 'composer', 'disc', 'disc_total', 'duration',
     'filesize', 'filename', 'genre', 'samplerate', 'title', 'track',
@@ -26,112 +24,99 @@ tinytag_attributes = {
 }
 
 
-def run_cli(args: str) -> str:
-    debug_env = str(os.environ.pop("TINYTAG_DEBUG", None))
-    output = check_output(
-        f'{sys.executable} -m tinytag ' + args, cwd=project_folder,
-        shell=True, stderr=STDOUT)
-    if debug_env:
-        os.environ["TINYTAG_DEBUG"] = debug_env
-    return output.decode('utf-8')
+class TestCLI(TestCase):
 
+    @staticmethod
+    def run_cli(args: str) -> str:
+        debug_env = str(os.environ.pop("TINYTAG_DEBUG", None))
+        output = check_output(
+            f'{executable} -m tinytag ' + args, cwd=PROJECT_FOLDER,
+            shell=True, stderr=STDOUT)
+        if debug_env:
+            os.environ["TINYTAG_DEBUG"] = debug_env
+        return output.decode('utf-8')
 
-def file_size(filename: str) -> int:
-    return os.stat(filename).st_size
+    def test_wrong_params(self) -> None:
+        with self.assertRaises(CalledProcessError) as excinfo:
+            self.run_cli('-lol')
+        output = excinfo.exception.stdout.strip()
+        self.assertEqual(
+            output, b"-lol: [Errno 2] No such file or directory: '-lol'")
 
+    def test_print_help(self) -> None:
+        self.assertIn('tinytag [options] <filename', self.run_cli('-h'))
+        self.assertIn('tinytag [options] <filename', self.run_cli('--help'))
 
-def test_wrong_params() -> None:
-    with pytest.raises(CalledProcessError) as excinfo:
-        run_cli('-lol')
-    output = excinfo.value.stdout.strip()
-    assert output == b"-lol: [Errno 2] No such file or directory: '-lol'"
+    def test_save_image_long_opt(self) -> None:
+        with NamedTemporaryFile() as temp_file:
+            self.assertEqual(os.path.getsize(temp_file.name), 0)
+        self.run_cli(f'--save-image {temp_file.name} {MP3_WITH_IMG}')
+        self.assertGreater(os.path.getsize(temp_file.name), 0)
+        with open(temp_file.name, 'rb') as file_handle:
+            image_data = file_handle.read(20)
+            self.assertTrue(image_data.startswith(b'\xff'))
+            self.assertIn(b'JFIF', image_data)
 
+    def test_save_image_short_opt(self) -> None:
+        with NamedTemporaryFile() as temp_file:
+            self.assertEqual(os.path.getsize(temp_file.name), 0)
+        self.run_cli(f'-i {temp_file.name} {MP3_WITH_IMG}')
+        self.assertGreater(os.path.getsize(temp_file.name), 0)
 
-def test_print_help() -> None:
-    assert 'tinytag [options] <filename' in run_cli('-h')
-    assert 'tinytag [options] <filename' in run_cli('--help')
+    def test_save_image_bulk(self) -> None:
+        temp_name = None
+        with NamedTemporaryFile(suffix='.jpg') as temp_file:
+            temp_name = temp_file.name
+            temp_name_no_ext = temp_name[:-4]
+            self.assertEqual(os.path.getsize(temp_name), 0)
+        self.run_cli(
+            f'-i {temp_name} {MP3_WITH_IMG} {MP3_WITH_IMG} {MP3_WITH_IMG}')
+        self.assertFalse(os.path.isfile(temp_name))
+        self.assertGreater(os.path.getsize(temp_name_no_ext + '00000.jpg'), 0)
+        self.assertGreater(os.path.getsize(temp_name_no_ext + '00001.jpg'), 0)
+        self.assertGreater(os.path.getsize(temp_name_no_ext + '00002.jpg'), 0)
 
+    def test_meta_data_output_default_json(self) -> None:
+        output = self.run_cli(MP3_WITH_IMG)
+        data = json.loads(output)
+        self.assertTrue(data)
+        self.assertTrue(set(data.keys()).issubset(TINYTAG_ATTRIBUTES))
 
-def test_save_image_long_opt() -> None:
-    with NamedTemporaryFile() as temp_file:
-        assert file_size(temp_file.name) == 0
-    run_cli(f'--save-image {temp_file.name} {mp3_with_img}')
-    assert file_size(temp_file.name) > 0
-    with open(temp_file.name, 'rb') as file_handle:
-        image_data = file_handle.read(20)
-        assert image_data.startswith(b'\xff')
-        assert b'JFIF' in image_data
+    def test_meta_data_output_format_json(self) -> None:
+        output = self.run_cli('-f json ' + MP3_WITH_IMG)
+        data = json.loads(output)
+        self.assertTrue(data)
+        self.assertTrue(set(data.keys()).issubset(TINYTAG_ATTRIBUTES))
 
+    def test_meta_data_output_format_csv(self) -> None:
+        output = self.run_cli('-f csv ' + MP3_WITH_IMG)
+        lines = [line for line in output.split(os.linesep) if line]
+        self.assertTrue(all(',' in line for line in lines))
+        attributes = set(line.split(',')[0] for line in lines)
+        self.assertTrue(set(attributes).issubset(TINYTAG_ATTRIBUTES))
 
-def test_save_image_short_opt() -> None:
-    with NamedTemporaryFile() as temp_file:
-        assert file_size(temp_file.name) == 0
-    run_cli(f'-i {temp_file.name} {mp3_with_img}')
-    assert file_size(temp_file.name) > 0
+    def test_meta_data_output_format_tsv(self) -> None:
+        output = self.run_cli('-f tsv ' + MP3_WITH_IMG)
+        lines = [line for line in output.split(os.linesep) if line]
+        self.assertTrue(all('\t' in line for line in lines))
+        attributes = set(line.split('\t')[0] for line in lines)
+        self.assertTrue(set(attributes).issubset(TINYTAG_ATTRIBUTES))
 
+    def test_meta_data_output_format_tabularcsv(self) -> None:
+        output = self.run_cli('-f tabularcsv ' + MP3_WITH_IMG)
+        header, _line, _rest = output.split(os.linesep)
+        self.assertTrue(set(header.split(',')).issubset(TINYTAG_ATTRIBUTES))
 
-def test_save_image_bulk() -> None:
-    temp_name = None
-    with NamedTemporaryFile(suffix='.jpg') as temp_file:
-        temp_name = temp_file.name
-        temp_name_no_ext = temp_name[:-4]
-        assert file_size(temp_name) == 0
-    run_cli(f'-i {temp_name} {mp3_with_img} {mp3_with_img} {mp3_with_img}')
-    assert not os.path.isfile(temp_name)
-    assert file_size(temp_name_no_ext + '00000.jpg') > 0
-    assert file_size(temp_name_no_ext + '00001.jpg') > 0
-    assert file_size(temp_name_no_ext + '00002.jpg') > 0
+    def test_meta_data_output_format_invalid(self) -> None:
+        output = self.run_cli('-f invalid ' + MP3_WITH_IMG)
+        self.assertFalse(output)
 
+    def test_fail_on_unsupported_file(self) -> None:
+        with self.assertRaises(CalledProcessError):
+            self.run_cli(BOGUS_FILE)
 
-def test_meta_data_output_default_json() -> None:
-    output = run_cli(mp3_with_img)
-    data = json.loads(output)
-    assert data
-    assert set(data.keys()).issubset(tinytag_attributes)
+    def test_fail_skip_unsupported_file_long_opt(self) -> None:
+        self.run_cli('--skip-unsupported ' + BOGUS_FILE)
 
-
-def test_meta_data_output_format_json() -> None:
-    output = run_cli('-f json ' + mp3_with_img)
-    data = json.loads(output)
-    assert data
-    assert set(data.keys()).issubset(tinytag_attributes)
-
-
-def test_meta_data_output_format_csv() -> None:
-    output = run_cli('-f csv ' + mp3_with_img)
-    lines = [line for line in output.split(os.linesep) if line]
-    assert all(',' in line for line in lines)
-    attributes = set(line.split(',')[0] for line in lines)
-    assert set(attributes).issubset(tinytag_attributes)
-
-
-def test_meta_data_output_format_tsv() -> None:
-    output = run_cli('-f tsv ' + mp3_with_img)
-    lines = [line for line in output.split(os.linesep) if line]
-    assert all('\t' in line for line in lines)
-    attributes = set(line.split('\t')[0] for line in lines)
-    assert set(attributes).issubset(tinytag_attributes)
-
-
-def test_meta_data_output_format_tabularcsv() -> None:
-    output = run_cli('-f tabularcsv ' + mp3_with_img)
-    header, _line, _rest = output.split(os.linesep)
-    assert set(header.split(',')).issubset(tinytag_attributes)
-
-
-def test_meta_data_output_format_invalid() -> None:
-    output = run_cli('-f invalid ' + mp3_with_img)
-    assert not output
-
-
-def test_fail_on_unsupported_file() -> None:
-    with pytest.raises(CalledProcessError):
-        run_cli(bogus_file)
-
-
-def test_fail_skip_unsupported_file_long_opt() -> None:
-    run_cli('--skip-unsupported ' + bogus_file)
-
-
-def test_fail_skip_unsupported_file_short_opt() -> None:
-    run_cli('-s ' + bogus_file)
+    def test_fail_skip_unsupported_file_short_opt(self) -> None:
+        self.run_cli('-s ' + BOGUS_FILE)


### PR DESCRIPTION
There isn't a good enough reason to prefer a third-party library over the built-in unittest module in this case. Our tests are quite simple.