### PR TITLE
ASF: Decode strings as UTF-16LE instead of system byte order

### DIFF
--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -2299,7 +2299,7 @@ class _ASF(TinyTag):
                 }
                 for i_field_name, length in data_blocks.items():
                     value = self._unpad(
-                        walker.read(length).decode('utf-16', 'replace'))
+                        walker.read(length).decode('utf-16le', 'replace'))
                     if not i_field_name.startswith('_') and value:
                         self._set_field(i_field_name, value)
             elif (self._parse_tags
@@ -2310,7 +2310,7 @@ class _ASF(TinyTag):
                 for _ in range(descriptor_count):
                     name_len = unpack('<H', walker.read(2))[0]
                     name = self._unpad(
-                        walker.read(name_len).decode('utf-16', 'replace'))
+                        walker.read(name_len).decode('utf-16le', 'replace'))
                     value_type, value_len = unpack('<HH', walker.read(4))
                     self._parse_value(walker, name, value_type, value_len)
             elif (self._parse_tags
@@ -2338,7 +2338,7 @@ class _ASF(TinyTag):
                             value_len = unpack('<I', walker.read(4))[0]
                             name = self._unpad(
                                 walker.read(name_len)
-                                .decode('utf-16', 'replace'))
+                                .decode('utf-16le', 'replace'))
                             self._parse_value(
                                 walker, name, value_type, value_len)
                     else:
@@ -2390,7 +2390,8 @@ class _ASF(TinyTag):
                      value_len: int) -> None:
         # Unicode string
         if value_type == 0:
-            value = self._unpad(fh.read(value_len).decode('utf-16', 'replace'))
+            value = self._unpad(
+                fh.read(value_len).decode('utf-16le', 'replace'))
         # DWORD / QWORD / WORD
         elif (1 < value_type < 6
                 and value_len in self._UNPACK_FORMATS):


### PR DESCRIPTION
Fixes parsing on big-endian architectures like s390x.

Fixes #361